### PR TITLE
Add configuration loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_include_directories(
 target_sources(
     ${PROJECT_NAME}
     PRIVATE
+        src/utilities.cpp
         src/main.cpp
 )
 

--- a/load.py
+++ b/load.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Joe Porembski
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+__author__ = 'Joe Porembski'
+__copyright__ = 'Copyright (C) 2023 Joe Porembski'
+__license__ = 'BSD-3-Clause'
+
+import argparse
+import subprocess
+import os
+
+PICO_TOTAL_MEMORY_BYTES : int = (256+2)*1024*1024
+MAXIMUM_NUMBER_OF_GARAGE_DOORS : int = 12
+CONFIGURATION_DIRECTORY : str = 'build'
+CONFIGURATION_FILE : str = 'build/picocfg.bin'
+PICOTOOL_COMMAND : str = 'picotool'
+LOAD_OPTION : str = 'load'
+OFFSET_OPTION : str = '--offset'
+FORCE_OPTION : str = '-f'
+
+def writeConfigurationInteger(value : int, first_write : bool = False):
+    option = 'ab'
+    if first_write:
+        option = 'wb'
+
+    valueByte = value & 0xFF
+    with open(CONFIGURATION_FILE, option) as configuration_file:
+        configuration_file.write(bytes([valueByte]))
+        print('Wrote {}'.format(valueByte))
+        
+        # This function only ever writes a single byte
+        return 1
+
+def writeConfigurationString(value : str, first_write : bool = False):
+    option = 'ab'
+    if first_write:
+        option = 'wb'
+
+    with open(CONFIGURATION_FILE, option) as configuration_file:
+        valueBytes = bytearray(value, encoding='utf-8')
+        valueLength = len(value)
+        configuration_file.write(valueLength.to_bytes(4, 'little'))
+        configuration_file.write(valueBytes)
+        print('Wrote {} ({} bytes)'.format(value, valueLength))
+        
+        # Adding 4 to account for the 4 byte length
+        return valueLength + 4
+
+if __name__ == '__main__':
+    # First step here is to parse the arguments.
+    # All arguments are setup with a default to ensure they can be naively referenced later.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--ssid', default='', help='The Wireless SSID the device should connect to')
+    parser.add_argument('-p', '--passphrase', default='', help='The passphrase of the specified Wireless SSID')
+    parser.add_argument('-b', '--broker', default='', help='The MQTT Broker to connect to')
+    parser.add_argument('-d', '--device', default='', help='The device name')
+    parser.add_argument('--doors', nargs="+", help='The pins to be used for each garage door')
+    args = parser.parse_args()
+    
+    if not os.path.exists(CONFIGURATION_DIRECTORY):
+        os.makedirs(CONFIGURATION_DIRECTORY)
+        
+    num_garages = min(len(args.doors), MAXIMUM_NUMBER_OF_GARAGE_DOORS)
+
+    # Second step is to create the configuration file.
+    # Configuration file will be defined as a binary encoded file with the following values written in order:
+    #   Number of Garages (Fixed 1-byte length)
+    #   Garage Pins (1-byte each)
+    #   SSID Length (Fixed 4-byte length)
+    #   SSID
+    #   Passphrase Length (Fixed 4-byte length)
+    #   Passphrase
+    #   Broker Name Length (Fixed 4-byte length)
+    #   Broker Name
+    #   Device Name Length (Fixed 4-byte length)
+    #   Device Name
+    #   Total Length (Fixed 4-byte length)
+    #
+    # This will allow the pico code to pull the configuration length from a fixed location (last 4 bytes in memory).
+    totalLength = writeConfigurationInteger(num_garages, True)
+    for index in range(num_garages):
+        totalLength += writeConfigurationInteger(int(args.doors[index]))
+    totalLength += writeConfigurationString(args.ssid)
+    totalLength += writeConfigurationString(args.passphrase)
+    totalLength += writeConfigurationString(args.broker)
+    totalLength += writeConfigurationString(args.device)
+    with open(CONFIGURATION_FILE, 'ab') as configuration_file:
+        configuration_file.write(totalLength.to_bytes(4, 'little'))
+        totalLength += 4
+    print('Created {} ({} bytes)'.format(CONFIGURATION_FILE, totalLength))
+
+    # Final step is to use picotool to load the configuration file
+    # at the very end of the flash memory of the Pico.
+    offset = PICO_TOTAL_MEMORY_BYTES - totalLength
+    offsetStr = ('0x{0:8x}').format(offset)
+    print('Writing {} to pico @ {}'.format(CONFIGURATION_FILE, offsetStr))
+    picoload_command = [
+        PICOTOOL_COMMAND, LOAD_OPTION, FORCE_OPTION, CONFIGURATION_FILE, OFFSET_OPTION, offsetStr
+    ]
+    subprocess.call(picoload_command)

--- a/src/generated/configuration.hpp.in
+++ b/src/generated/configuration.hpp.in
@@ -16,4 +16,8 @@ inline constexpr uint8_t SYSTEM_LED_PIN = @SYSTEM_LED_PIN@;
 /** GPIO Pin for the Feedback LED used by the DHT Sensor */
 inline constexpr uint8_t MQTT_FEEDBACK_PIN = @MQTT_FEEDBACK_PIN@;
 
+inline constexpr size_t TOPIC_BUFFER_SIZE = UINT8_MAX;
+inline constexpr std::string_view PROGRAM_TOPIC_FORMAT = "%s";
+inline constexpr std::string_view VERSION_TOPIC_FORMAT = "%s/version";
+inline constexpr std::string_view UID_TOPIC_FORMAT = "%s/uid";
 // clang-format on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,16 +4,85 @@ SPDX-License-Identifier: BSD-3-Clause
 ------------------------------------------------------------------------------*/
 #include "generated/configuration.hpp"
 #include "gpio.hpp"
-
 #include "mqtt.hpp"
+#include "utilities.hpp"
 
+#include <hardware/adc.h>
 #include <hardware/gpio.h>
+#include <pico/stdio.h>
 
-int main(int argc, char** argv)
+#include <cstdint>
+#include <string>
+
+inline constexpr uint32_t COMMUNICATION_PERIOD_MS = 10000;
+inline constexpr uint32_t MQTT_CONNECTION_WAIT_MS = 17500;
+
+static void initialize()
 {
+    stdio_init_all();
+    adc_init();
+
     gpio_init(SYSTEM_LED_PIN);
     gpio_set_dir(SYSTEM_LED_PIN, GPIO_OUT);
     gpio_put(SYSTEM_LED_PIN, ON);
+}
 
-    mqtt::Client mqtt("Fomalhaut", CONFIGURED_MQTT_PORT, "test", MQTT_FEEDBACK_PIN);
+static bool initializeMQTT(mqtt::Client& client, const std::string& uid)
+{
+    char mqtt_topic[TOPIC_BUFFER_SIZE];
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, VERSION_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    if (!client.publish(mqtt_topic, static_cast<const void*>(VERSION.data()), VERSION.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
+        printf("Failed to publish %s\n", mqtt_topic);
+        return false;
+    }
+
+    snprintf(mqtt_topic, TOPIC_BUFFER_SIZE, UID_TOPIC_FORMAT.data(), client.deviceName().c_str());
+    if (!client.publish(mqtt_topic, static_cast<const void*>(uid.c_str()), uid.size(), mqtt::QoS::EXACTLY_ONCE, true)) {
+        printf("Failed to publish %s\n", mqtt_topic);
+        return false;
+    }
+
+    printf("Successfully initialized MQTT\n");
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    initialize();
+    std::string board_id = systemIdentifier();
+    bool mqtt_initialized = false;
+    uint32_t count = 0;
+
+    sleep_ms(5000);
+    SystemConfiguration cfg;
+    if (!read(cfg)) {
+        printf("Failed to read system configuration\n");
+        return EXIT_FAILURE;
+    }
+
+    mqtt::Client client(cfg.mqttBroker(), CONFIGURED_MQTT_PORT, cfg.deviceName(), MQTT_FEEDBACK_PIN);
+
+    while (true) {
+        if (!client.connected()) {
+            printf("Connecting MQTT...\n");
+            mqtt_initialized = false;
+            client.connect();
+            sleep_ms(MQTT_CONNECTION_WAIT_MS);
+            continue;
+        }
+
+        if (!mqtt_initialized) {
+            printf("Initializing MQTT...\n");
+            mqtt_initialized = initializeMQTT(client, board_id);
+            sleep_ms(COMMUNICATION_PERIOD_MS);
+            continue;
+        }
+
+        printf("\n----------------- [%u]\n", count);
+        printf("MQTT Status: %s\n", client.connected() ? "true" : "false");
+        printf("-----------------\n");
+
+        sleep_ms(COMMUNICATION_PERIOD_MS);
+        count++;
+    }
 }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1,0 +1,186 @@
+/*------------------------------------------------------------------------------
+Copyright (c) 2023 Joe Porembski
+SPDX-License-Identifier: BSD-3-Clause
+------------------------------------------------------------------------------*/
+
+#include "utilities.hpp"
+
+#include "gpio.hpp"
+
+#include <hardware/flash.h>
+#include <hardware/gpio.h>
+#include <pico/time.h>
+#include <pico/types.h>
+#include <pico/unique_id.h>
+
+#include <cstdint>
+#include <cstring>
+
+
+inline constexpr size_t UID_SIZE = 2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1;
+inline constexpr size_t CONFIGURATION_OFFSET = PICO_FLASH_SIZE_BYTES - sizeof(uint32_t);
+inline constexpr size_t CONFIGURATION_MAX_SIZE = 1024;
+inline constexpr size_t STRING_MAX_SIZE = 256;
+inline constexpr int32_t STRING_IS_TOO_BIG = -1;
+
+
+static int32_t consumeString(const std::vector<uint8_t>& serialized_data, size_t starting_index, std::string& deserialized_data)
+{
+    uint32_t string_size;
+    std::memcpy(&string_size, &serialized_data[starting_index], sizeof(uint32_t));
+    size_t string_index = starting_index + sizeof(uint32_t);
+    size_t end_index = string_index + string_size;
+
+    printf("Reading configuration string from index %lu\n", starting_index);
+    if (string_size > STRING_MAX_SIZE || end_index > serialized_data.size()) {
+        printf("Failed to read: [String size: %u, End: %u, data size: %lu]\n", string_size, end_index, serialized_data.size());
+        return STRING_IS_TOO_BIG;
+    }
+
+    auto string_start = serialized_data.begin() + string_index;
+    auto string_end = serialized_data.begin() + end_index;
+    deserialized_data.assign(string_start, string_end);
+    // This cast can be done naively because of the check against STRING_MAX_SIZE
+    return static_cast<int32_t>(string_size + sizeof(uint32_t));
+}
+
+SystemConfiguration::SystemConfiguration() : _ssid(), _passphrase(), _mqtt_broker(), _device_name()
+{}
+
+SystemConfiguration::SystemConfiguration(const std::vector<uint8_t>& configuration) : _ssid(), _passphrase(), _mqtt_broker(), _device_name()
+{
+    _parse(configuration);
+}
+
+const std::string& SystemConfiguration::deviceName() const
+{
+    return _device_name;
+}
+
+const std::vector<uint8_t>& SystemConfiguration::doorPins() const
+{
+    return _door_pins;
+}
+
+const std::string& SystemConfiguration::mqttBroker() const
+{
+    return _mqtt_broker;
+}
+
+const std::string& SystemConfiguration::passphrase() const
+{
+    return _passphrase;
+}
+
+const std::string& SystemConfiguration::ssid() const
+{
+    return _ssid;
+}
+
+void SystemConfiguration::_parse(const std::vector<uint8_t>& configuration)
+{
+    // The order here is paramount.
+    // The configuration file is (in forward order):
+    //   - Number of Garages (Fixed 1-byte length)
+    //   - Garage Pins (1-byte each)
+    //   - SSID Length (Fixed 4-byte length)
+    //   - SSID
+    //   - Passphrase Length (Fixed 4-byte length)
+    //   - Passphrase
+    //   - MQTT Broker Length (Fixed 4-byte length)
+    //   - MQTT Broker
+    //   - Device Name Length (Fixed 4-byte length)
+    //   - Device Name
+    size_t current_index = 0;
+
+    _door_pins.resize(configuration[current_index]);
+    current_index++;
+
+    for(size_t pin_index = 0; pin_index < _door_pins.size(); pin_index++) {
+        _door_pins[pin_index] = configuration[current_index];
+        current_index++;
+    }
+
+    int32_t consumed_bytes = consumeString(configuration, current_index, _ssid);
+    current_index += consumed_bytes;
+    if (consumed_bytes < 0 || current_index >= configuration.size()) {
+        printf("Failed to read SSID from configuration: %d\n", consumed_bytes);
+        return;
+    }
+
+    consumed_bytes = consumeString(configuration, current_index, _passphrase);
+    current_index += consumed_bytes;
+    if (consumed_bytes < 0 || current_index >= configuration.size()) {
+        printf("Failed to read Passphrase from configuration: %d\n", consumed_bytes);
+    }
+
+    consumed_bytes = consumeString(configuration, current_index, _mqtt_broker);
+    current_index += consumed_bytes;
+    if (consumed_bytes < 0 || current_index >= configuration.size()) {
+        printf("Failed to read MQTT Broker from configuration: %d\n", consumed_bytes);
+    }
+
+    consumed_bytes = consumeString(configuration, current_index, _device_name);
+    if (consumed_bytes < 0) {
+        printf("Failed to read Device Name from configuration: %d\n", consumed_bytes);
+    }
+}
+
+uint64_t microseconds()
+{
+    return to_us_since_boot(get_absolute_time());
+}
+
+uint64_t milliseconds()
+{
+    return to_us_since_boot(get_absolute_time()) / 1000;
+}
+
+std::string systemIdentifier()
+{
+    char uid[UID_SIZE];
+    std::memset(uid, 0, UID_SIZE);
+    pico_get_unique_board_id_string(uid, UID_SIZE);
+    return uid;
+}
+
+bool wait(uint8_t gpio_pin, bool desired_state, uint64_t wait_length)
+{
+    uint64_t read_count = 0;
+    while (gpio_get(gpio_pin) != desired_state && read_count < wait_length) {
+        read_count += 10;
+        sleep_us(10);
+    }
+
+    return read_count < wait_length;
+}
+
+bool read(SystemConfiguration& cfg)
+{
+    // The order here is paramount.
+    // The configuration file is (in forward order):
+    //   - <Configuration Data>
+    //   - Total Configuration Length (Fixed 4-byte length)
+    //
+    // Meaning the last 4 bytes needs to be read off and some pointer math needs to be done to
+    // grab the configuration data.
+    //
+    // It should be noted that CONFIGURATION_OFFSET already shifts "up" 4-bytes to account for the length.
+    uint8_t* configuration_length_location = (uint8_t*)(XIP_BASE + CONFIGURATION_OFFSET);
+    uint32_t total_length = *((uint32_t*)configuration_length_location);
+    uint8_t* configuration_contents = (uint8_t*)(configuration_length_location - total_length);
+
+    // Rather than consuming in place, the entire chunk of configuration data will be read into
+    // a vector and then passed to the configuration object. Although not very efficient, as memory
+    // is duplicated twice, this does mean the SystemConfiguration class can be responsible for
+    // understanding the configuration contents, and a lot of pointer math is avoided. As of time of
+    // implementation, the configuration data is on the order of 50-60 bytes, so this appears like
+    // a small hit in memory efficiency for a more object-oriented design.
+    printf("Configuration contents are %u bytes @ 0x%08X\n", total_length, configuration_contents);
+    std::vector<uint8_t> configuration(total_length);
+    for (size_t i = 0; i < total_length; i++, configuration_contents++) {
+        configuration[i] = *(configuration_contents);
+    }
+    cfg = SystemConfiguration(configuration);
+    return true;
+}

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -1,0 +1,121 @@
+/*------------------------------------------------------------------------------
+Copyright (c) 2023 Joe Porembski
+SPDX-License-Identifier: BSD-3-Clause
+------------------------------------------------------------------------------*/
+#pragma once
+
+
+#include <pico/time.h>
+#include <pico/types.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+
+inline constexpr float C_TO_F_SCALE = 9.0 / 5.0;
+inline constexpr float C_TO_F_OFFSET = 32.0;
+
+/**
+ * Class encapsulating the configuration data for a device.
+ */
+class SystemConfiguration
+{
+public:
+    /** Constructor */
+    SystemConfiguration();
+
+    /**
+     * Constructor
+     *
+     * @param[in] configuration The configuration data read from flash memory.
+     */
+    SystemConfiguration(const std::vector<uint8_t>& configuration);
+
+    /**
+     * @return The device name to be used for MQTT communication.
+     */
+    const std::string& deviceName() const;
+
+    /**
+     * @return The list of pins to control the Garage Doors.
+     */
+    const std::vector<uint8_t>& doorPins() const;
+
+    /**
+     * @note The MQTT Broker can be an IPv4 address or a hostname. This should be passed through a DNS resolver.
+     * @return The MQTT Broker.
+     */
+    const std::string& mqttBroker() const;
+
+    /**
+     * @return The passphrase for the configured wireless network.
+     */
+    const std::string& passphrase() const;
+
+    /**
+     * @return The SSID of the configured wireless network.
+     */
+    const std::string& ssid() const;
+
+private:
+    /**
+     * Helper function to parse @a configuration.
+     *
+     * @param[in] configuration The configuration data read from flash memory.
+     */
+    void _parse(const std::vector<uint8_t>& configuration);
+
+    std::string _ssid;
+    std::string _passphrase;
+    std::string _mqtt_broker;
+    std::string _device_name;
+    std::vector<uint8_t> _door_pins;
+};
+
+/**
+ * @return The microseconds since boot.
+ */
+uint64_t microseconds();
+
+/**
+ * @return The milliseconds since boot.
+ */
+uint64_t milliseconds();
+
+/**
+ * @return The unique identifier of this system.
+ */
+std::string systemIdentifier();
+
+/**
+ * Waits on the to become @a desired_state.
+ *
+ * Will timeout after @a wait_length, and return false.
+ *
+ * @note This is a blocking wait.
+ * @param[in] gpio_pin The pin to wait on.
+ * @param[in] desired_state The desired state of @a gpio_pin.
+ * @param[in] wait_length The time to wait for it to enter this state in microseconds (us).
+ * @return True if the wait was successful, false otherwise.
+ */
+bool wait(uint8_t gpio_pin, bool desired_state, uint64_t wait_length);
+
+/**
+ * Reads the system configuration information from flash memory.
+ *
+ * @param[in] cfg The system configuration information to be read.
+ * @return True if the read was successful, false otherwise.
+ */
+bool read(SystemConfiguration& cfg);
+
+/**
+ * Converts a temperature in celsius to its equivalent in fahrenheit.
+ *
+ * @param[in] temperature The temperature in celsius.
+ * @return The value of @a temperature converted to fahrenheit.
+ */
+inline float toFahrenheit(float temperature)
+{
+    return (C_TO_F_SCALE * temperature) + C_TO_F_OFFSET;
+}


### PR DESCRIPTION
This commit adds in the ability to read in run-time configuration data from the
Pico's non-volatile memory. It also provides the `load.py` utility to load the
configuration data into the Pico such that it can be read out.

Resolves #3 